### PR TITLE
cli: add start command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module github.com/andydunstall/fuddle
 
 go 1.20
+
+require github.com/spf13/cobra v1.6.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
+github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -13,20 +13,32 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package cli
 
 import (
-	"fmt"
-	"math/rand"
-	"time"
-
-	"github.com/andydunstall/fuddle/pkg/cli"
+	"github.com/spf13/cobra"
 )
 
-func main() {
-	rand.Seed(time.Now().UnixNano())
+// fuddleCmd is the root command to run fuddle.
+var fuddleCmd = &cobra.Command{
+	Use:          "fuddle [command] (flags)",
+	Short:        "fuddle cli and server",
+	Long:         "fuddle cli and server",
+	SilenceUsage: true,
+	CompletionOptions: cobra.CompletionOptions{
+		DisableDefaultCmd: true,
+	},
+}
 
-	if err := cli.Start(); err != nil {
-		fmt.Println(err)
-	}
+func init() {
+	cobra.EnableCommandSorting = false
+
+	fuddleCmd.AddCommand(
+		startCmd,
+	)
+}
+
+// Start starts the CLI.
+func Start() error {
+	return fuddleCmd.Execute()
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -13,20 +13,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package main
+package cli
 
 import (
-	"fmt"
-	"math/rand"
-	"time"
-
-	"github.com/andydunstall/fuddle/pkg/cli"
+	"github.com/spf13/cobra"
 )
 
-func main() {
-	rand.Seed(time.Now().UnixNano())
+// startCmd starts a fuddle node.
+var startCmd = &cobra.Command{
+	Use:   "start",
+	Short: "start a fuddle node",
+	Long:  "start a fuddle node",
+	RunE:  runStart,
+}
 
-	if err := cli.Start(); err != nil {
-		fmt.Println(err)
-	}
+func runStart(cmd *cobra.Command, args []string) error {
+	return nil
 }


### PR DESCRIPTION
# Description
Adds a `fuddle start` command to the CLI to start a Fuddle node.