### PR TITLE
add admin service

### DIFF
--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -1,0 +1,79 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+type server struct {
+	httpServer *http.Server
+
+	logger *zap.Logger
+}
+
+func newServer(addr string, logger *zap.Logger) *server {
+	server := &server{
+		logger: logger,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/cluster", server.clusterRoute)
+
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+	server.httpServer = httpServer
+
+	return server
+}
+
+func (s *server) Start() error {
+	// Setup the listener before starting to the goroutine to return any errors
+	// binding or listening to the configured address.
+	ln, err := net.Listen("tcp", s.httpServer.Addr)
+	if err != nil {
+		return fmt.Errorf("admin server: %w", err)
+	}
+
+	s.logger.Info(
+		"starting admin server",
+		zap.String("addr", s.httpServer.Addr),
+	)
+
+	go func() {
+		if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+			s.logger.Error("admin serve error", zap.Error(err))
+		}
+	}()
+
+	return nil
+}
+
+func (s *server) GracefulStop() {
+	if err := s.httpServer.Shutdown(context.Background()); err != nil {
+		s.logger.Error("failed to shut down admin server", zap.Error(err))
+	}
+}
+
+func (s *server) clusterRoute(w http.ResponseWriter, r *http.Request) {
+}

--- a/pkg/admin/service.go
+++ b/pkg/admin/service.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package admin
+
+import (
+	"github.com/andydunstall/fuddle/pkg/config"
+	"go.uber.org/zap"
+)
+
+type Service struct {
+	logger *zap.Logger
+}
+
+func NewService(conf *config.Config, logger *zap.Logger) *Service {
+	logger = logger.With(zap.String("service", "admin"))
+
+	return &Service{
+		logger: logger,
+	}
+}
+
+func (s *Service) Start() error {
+	s.logger.Info("starting admin service")
+	return nil
+}
+
+func (s *Service) GracefulStop() {
+	s.logger.Info("starting admin service graceful shutdown")
+}

--- a/pkg/admin/service.go
+++ b/pkg/admin/service.go
@@ -21,22 +21,27 @@ import (
 )
 
 type Service struct {
+	server *server
+
 	logger *zap.Logger
 }
 
 func NewService(conf *config.Config, logger *zap.Logger) *Service {
 	logger = logger.With(zap.String("service", "admin"))
 
+	server := newServer(conf.BindAdminAddr, logger)
 	return &Service{
+		server: server,
 		logger: logger,
 	}
 }
 
 func (s *Service) Start() error {
 	s.logger.Info("starting admin service")
-	return nil
+	return s.server.Start()
 }
 
 func (s *Service) GracefulStop() {
 	s.logger.Info("starting admin service graceful shutdown")
+	s.server.GracefulStop()
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -30,6 +30,11 @@ var (
 	bindAddr string
 	// advAddr is the address the server should advertise to clients.
 	advAddr string
+
+	// bindAdminAddr is the bind address to listen for admin clients.
+	bindAdminAddr string
+	// advAdminAddr is the address to advertise to admin clients.
+	advAdminAddr string
 )
 
 // startCmd starts a fuddle node.
@@ -43,7 +48,7 @@ var startCmd = &cobra.Command{
 func init() {
 	startCmd.Flags().StringVarP(
 		&bindAddr,
-		"addr", "a",
+		"addr", "",
 		"0.0.0.0:8220",
 		"the bind address to listen for connections",
 	)
@@ -53,6 +58,19 @@ func init() {
 		"",
 		"the address to advertise to clients (defaults to the bind address)",
 	)
+
+	startCmd.Flags().StringVarP(
+		&bindAdminAddr,
+		"admin-addr", "",
+		"0.0.0.0:8221",
+		"the bind address to listen for admin connections",
+	)
+	startCmd.Flags().StringVarP(
+		&advAddr,
+		"adv-admin-addr", "",
+		"",
+		"the address to advertise to admin clients (defaults to the bind address)",
+	)
 }
 
 func runStart(cmd *cobra.Command, args []string) {
@@ -60,9 +78,15 @@ func runStart(cmd *cobra.Command, args []string) {
 	conf := &config.Config{
 		BindAddr: bindAddr,
 		AdvAddr:  bindAddr,
+
+		BindAdminAddr: bindAdminAddr,
+		AdvAdminAddr:  bindAdminAddr,
 	}
 	if advAddr != "" {
 		conf.AdvAddr = bindAddr
+	}
+	if advAdminAddr != "" {
+		conf.AdvAdminAddr = bindAdminAddr
 	}
 
 	server := server.NewServer(conf, logger)

--- a/pkg/client/registry.go
+++ b/pkg/client/registry.go
@@ -48,7 +48,7 @@ func (r *Registry) Register(ctx context.Context, id string) error {
 		NodeId: id,
 	})
 	if err != nil {
-		return fmt.Errorf("registry client: register: %s", err)
+		return fmt.Errorf("registry client: register: %w", err)
 	}
 	return nil
 }
@@ -58,7 +58,7 @@ func (r *Registry) Unregister(ctx context.Context, id string) error {
 		NodeId: id,
 	})
 	if err != nil {
-		return fmt.Errorf("registry client: unregister: %s", err)
+		return fmt.Errorf("registry client: unregister: %w", err)
 	}
 	return nil
 }
@@ -66,7 +66,7 @@ func (r *Registry) Unregister(ctx context.Context, id string) error {
 func (r *Registry) Nodes(ctx context.Context) ([]string, error) {
 	resp, err := r.client.Nodes(context.Background(), &rpc.NodesRequest{})
 	if err != nil {
-		return nil, fmt.Errorf("registry client: nodes: %s", err)
+		return nil, fmt.Errorf("registry client: nodes: %w", err)
 	}
 	return resp.Ids, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,10 +25,19 @@ type Config struct {
 	BindAddr string
 	// AdvAddr is the address to advertise to clients.
 	AdvAddr string
+
+	// BindAdminAddr is the bind address to listen for admin clients.
+	BindAdminAddr string
+	// AdvAdminAddr is the address to advertise to admin clients.
+	AdvAdminAddr string
 }
 
 func (c *Config) MarshalLogObject(e zapcore.ObjectEncoder) error {
 	e.AddString("bind-addr", c.BindAddr)
 	e.AddString("adv-addr", c.AdvAddr)
+
+	e.AddString("bind-admin-addr", c.BindAdminAddr)
+	e.AddString("adv-admin-addr", c.AdvAdminAddr)
+
 	return nil
 }

--- a/pkg/registry/service.go
+++ b/pkg/registry/service.go
@@ -51,3 +51,7 @@ func (s *Service) GracefulStop() {
 func (s *Service) Server() *Server {
 	return s.server
 }
+
+func (s *Service) NodeMap() *NodeMap {
+	return s.nodeMap
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -16,6 +16,7 @@
 package server
 
 import (
+	"github.com/andydunstall/fuddle/pkg/admin"
 	"github.com/andydunstall/fuddle/pkg/config"
 	"github.com/andydunstall/fuddle/pkg/registry"
 	"github.com/andydunstall/fuddle/pkg/rpc"
@@ -24,7 +25,7 @@ import (
 
 // Server runs a fuddle node.
 type Server struct {
-	adminService    *registry.Service
+	adminService    *admin.Service
 	registryService *registry.Service
 
 	grpcServer *grpcServer
@@ -36,7 +37,7 @@ type Server struct {
 func NewServer(conf *config.Config, logger *zap.Logger) *Server {
 	logger = logger.With(zap.String("service", "server"))
 
-	adminService := registry.NewService(conf, logger)
+	adminService := admin.NewService(conf, logger)
 	registryService := registry.NewService(conf, logger)
 
 	grpcServer := newGRPCServer(conf.BindAddr, logger)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -24,6 +24,7 @@ import (
 
 // Server runs a fuddle node.
 type Server struct {
+	adminService    *registry.Service
 	registryService *registry.Service
 
 	grpcServer *grpcServer
@@ -35,12 +36,14 @@ type Server struct {
 func NewServer(conf *config.Config, logger *zap.Logger) *Server {
 	logger = logger.With(zap.String("service", "server"))
 
+	adminService := registry.NewService(conf, logger)
 	registryService := registry.NewService(conf, logger)
 
 	grpcServer := newGRPCServer(conf.BindAddr, logger)
 	rpc.RegisterRegistryServer(grpcServer.GRPCServer(), registryService.Server())
 
 	return &Server{
+		adminService:    adminService,
 		registryService: registryService,
 		grpcServer:      grpcServer,
 		conf:            conf,
@@ -52,6 +55,9 @@ func NewServer(conf *config.Config, logger *zap.Logger) *Server {
 func (s *Server) Start() error {
 	s.logger.Info("starting node", zap.Object("conf", s.conf))
 
+	if err := s.adminService.Start(); err != nil {
+		return err
+	}
 	if err := s.registryService.Start(); err != nil {
 		return err
 	}
@@ -66,4 +72,5 @@ func (s *Server) GracefulStop() {
 	s.logger.Info("starting node graceful shutdown")
 	s.grpcServer.GracefulStop()
 	s.registryService.GracefulStop()
+	s.adminService.GracefulStop()
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,8 +37,8 @@ type Server struct {
 func NewServer(conf *config.Config, logger *zap.Logger) *Server {
 	logger = logger.With(zap.String("service", "server"))
 
-	adminService := admin.NewService(conf, logger)
 	registryService := registry.NewService(conf, logger)
+	adminService := admin.NewService(registryService.NodeMap(), conf, logger)
 
 	grpcServer := newGRPCServer(conf.BindAddr, logger)
 	rpc.RegisterRegistryServer(grpcServer.GRPCServer(), registryService.Server())

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -26,7 +26,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestRegistry_RegisterAndUnregisterNode(t *testing.T) {
+func TestAdmin_ListRegisteredNodes(t *testing.T) {
 	conf := testConfig()
 	server := server.NewServer(conf, zap.NewNop())
 	assert.Nil(t, server.Start())
@@ -38,7 +38,9 @@ func TestRegistry_RegisterAndUnregisterNode(t *testing.T) {
 	assert.Nil(t, registry.Register(context.TODO(), "node-1"))
 	assert.Nil(t, registry.Register(context.TODO(), "node-2"))
 
-	nodeIDs, err := registry.Nodes(context.TODO())
+	admin := client.NewAdmin(conf.AdvAdminAddr)
+
+	nodeIDs, err := admin.Nodes(context.TODO())
 	assert.Nil(t, err)
 	// Sort to make comparison easier.
 	sort.Strings(nodeIDs)
@@ -46,7 +48,7 @@ func TestRegistry_RegisterAndUnregisterNode(t *testing.T) {
 
 	assert.Nil(t, registry.Unregister(context.TODO(), "node-1"))
 
-	nodeIDs, err = registry.Nodes(context.TODO())
+	nodeIDs, err = admin.Nodes(context.TODO())
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"node-2"}, nodeIDs)
 }

--- a/tests/server.go
+++ b/tests/server.go
@@ -13,36 +13,32 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package admin
+package tests
 
 import (
+	"net"
+
 	"github.com/andydunstall/fuddle/pkg/config"
-	"github.com/andydunstall/fuddle/pkg/registry"
-	"go.uber.org/zap"
 )
 
-type Service struct {
-	server *server
+func testConfig() *config.Config {
+	conf := &config.Config{}
 
-	logger *zap.Logger
+	conf.BindAddr = getSystemAddress()
+	conf.AdvAddr = conf.BindAddr
+
+	conf.BindAdminAddr = getSystemAddress()
+	conf.AdvAdminAddr = conf.BindAdminAddr
+
+	return conf
 }
 
-func NewService(nodeMap *registry.NodeMap, conf *config.Config, logger *zap.Logger) *Service {
-	logger = logger.With(zap.String("service", "admin"))
-
-	server := newServer(conf.BindAdminAddr, nodeMap, logger)
-	return &Service{
-		server: server,
-		logger: logger,
+func getSystemAddress() string {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(err)
 	}
-}
+	defer ln.Close()
 
-func (s *Service) Start() error {
-	s.logger.Info("starting admin service")
-	return s.server.Start()
-}
-
-func (s *Service) GracefulStop() {
-	s.logger.Info("starting admin service graceful shutdown")
-	s.server.GracefulStop()
+	return ln.Addr().String()
 }


### PR DESCRIPTION
# Description
Adds an admin service that exposes endpoints to inspect the cluster.

This only includes the endpoint `/v1/api/cluster`.

## Testing
Adds a system test for the above endpoint.
