### PR TITLE
[WIP] remove grpc

### DIFF
--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -1,0 +1,25 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package server
+
+type httpServer struct {
+}
+
+// TODO write a http server the same way as grpc - where you register endpoints
+// before starting
+
+
+// return Routes map[string]func(w *http.ResponseWriter, r)


### PR DESCRIPTION
# Description
Using a gRPC server is for the public endpoint is overkill since its a relatively simple API.

gRPC also requires a separate port for admin and client traffic, and reimplementing a lot of the APIs for admin (which must be served via HTTP for the dashboard).

TODO though grpc streams could be useful for sending node udpates via a stream? instead would need longpoll or ws?

# Changes
## HTTP Server
Adds a `httpServer` where services register endpoints. Services servers expose a `func Routes() map[string]Endpoint` method, where `Endpoint` includes the path, method and handler. So before the HTTP server starts these services endpoints are registered. This also makes testing easier, such as can just call `s.Routes()["/v1/api/foo"](...)`.

## Testing
*Describe how the changes have been tested.*

## Docs
*Describe any documentation updates needed, or why there was no need to update documentation.*

## Admin
*Does the change require any updates admin API endpoints to inspect the cluster status?*

## Metrics
*Does the change require exposing any metrics to monitor the cluster?*

## Compatibility
*Are there any issues with compatibility these should be made clear? Such as if does it require a new major version?*
