### PR TITLE
config: add missing zap log fields

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,11 +42,15 @@ type Config struct {
 }
 
 func (c *Config) MarshalLogObject(e zapcore.ObjectEncoder) error {
+	e.AddString("id", c.ID)
+
 	e.AddString("bind-addr", c.BindAddr)
 	e.AddString("adv-addr", c.AdvAddr)
 
 	e.AddString("bind-admin-addr", c.BindAdminAddr)
 	e.AddString("adv-admin-addr", c.AdvAdminAddr)
+
+	e.AddString("locality", c.Locality)
 
 	e.AddString("revision", c.Revision)
 


### PR DESCRIPTION
Adds fields `Locality` and `ID` that are missing from the config log mashaler