### PR TITLE
add counter frontend

### DIFF
--- a/demos/counter/pkg/service/frontend/options.go
+++ b/demos/counter/pkg/service/frontend/options.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package frontend
+
+import (
+	"go.uber.org/zap"
+)
+
+type options struct {
+	logger *zap.Logger
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type loggerOption struct {
+	logger *zap.Logger
+}
+
+func (o loggerOption) apply(opts *options) {
+	opts.logger = o.logger
+}
+
+func WithLogger(logger *zap.Logger) Option {
+	return loggerOption{logger: logger}
+}

--- a/demos/counter/pkg/service/frontend/options.go
+++ b/demos/counter/pkg/service/frontend/options.go
@@ -16,11 +16,14 @@
 package frontend
 
 import (
+	"net"
+
 	"go.uber.org/zap"
 )
 
 type options struct {
-	logger *zap.Logger
+	logger     *zap.Logger
+	wsListener net.Listener
 }
 
 type Option interface {
@@ -37,4 +40,16 @@ func (o loggerOption) apply(opts *options) {
 
 func WithLogger(logger *zap.Logger) Option {
 	return loggerOption{logger: logger}
+}
+
+type wsListenerOption struct {
+	ln net.Listener
+}
+
+func (o wsListenerOption) apply(opts *options) {
+	opts.wsListener = o.ln
+}
+
+func WithWSListener(ln net.Listener) Option {
+	return wsListenerOption{ln: ln}
 }

--- a/demos/counter/pkg/service/frontend/server.go
+++ b/demos/counter/pkg/service/frontend/server.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2023 Andrew Dunstall
+//
+// Fuddle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Fuddle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package frontend
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+)
+
+type server struct {
+	httpServer *http.Server
+
+	logger *zap.Logger
+}
+
+func newServer(addr string, logger *zap.Logger) *server {
+	server := &server{
+		logger: logger,
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/{id}", server.registerRoute)
+
+	httpServer := &http.Server{
+		Addr:    addr,
+		Handler: r,
+	}
+	server.httpServer = httpServer
+
+	return server
+}
+
+func (s *server) Start(ln net.Listener) error {
+	if ln == nil {
+		// Setup the listener before starting to the goroutine to return any errors
+		// binding or listening to the configured address.
+		var err error
+		ln, err = net.Listen("tcp", s.httpServer.Addr)
+		if err != nil {
+			return fmt.Errorf("frontend server: %w", err)
+		}
+	}
+
+	s.logger.Info(
+		"starting frontend server",
+		zap.String("addr", s.httpServer.Addr),
+	)
+
+	go func() {
+		if err := s.httpServer.Serve(ln); err != nil && err != http.ErrServerClosed {
+			s.logger.Error("frontend serve error", zap.Error(err))
+		}
+	}()
+
+	return nil
+
+}
+
+func (s *server) GracefulStop() {
+	// Note this won't handle gracefully closing websocket connections, though
+	// thats fine for the demo.
+	if err := s.httpServer.Shutdown(context.Background()); err != nil {
+		s.logger.Error("failed to shut down frontend server", zap.Error(err))
+	}
+}
+
+func (s *server) registerRoute(w http.ResponseWriter, r *http.Request) {
+}

--- a/demos/counter/pkg/service/frontend/service.go
+++ b/demos/counter/pkg/service/frontend/service.go
@@ -31,7 +31,15 @@ type Service struct {
 	logger *zap.Logger
 }
 
-func NewService(conf *Config, logger *zap.Logger) *Service {
+func NewService(conf *Config, opts ...Option) *Service {
+	options := options{
+		logger: zap.NewNop(),
+	}
+	for _, o := range opts {
+		o.apply(&options)
+	}
+
+	logger := options.logger.With(zap.String("service", "counter"))
 	return &Service{
 		conf:   conf,
 		logger: logger,

--- a/demos/counter/pkg/testutils/cluster/options.go
+++ b/demos/counter/pkg/testutils/cluster/options.go
@@ -16,8 +16,9 @@
 package cluster
 
 type options struct {
-	fuddleNodes  int
-	counterNodes int
+	fuddleNodes   int
+	counterNodes  int
+	frontendNodes int
 }
 
 type Option interface {
@@ -42,4 +43,14 @@ func (c counterNodesOption) apply(opts *options) {
 
 func WithCounterNodes(c int) Option {
 	return counterNodesOption(c)
+}
+
+type frontendNodesOption int
+
+func (c frontendNodesOption) apply(opts *options) {
+	opts.frontendNodes = int(c)
+}
+
+func WithFrontendNodes(c int) Option {
+	return frontendNodesOption(c)
 }

--- a/demos/counter/tests/counter/frontend_test.go
+++ b/demos/counter/tests/counter/frontend_test.go
@@ -13,22 +13,29 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-package frontend
+package counter
 
-// Config contains the node configuration.
-type Config struct {
-	// ID is a unique identifier for the node.
-	ID string
+import (
+	"net/http"
+	"testing"
 
-	// WSAddr is the address to listen for WebSocket connections.
-	WSAddr string
+	"github.com/andydunstall/fuddle/demos/counter/pkg/testutils/cluster"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
-	// FuddleAddrs contains fuddle registry seed nodes.
-	FuddleAddrs []string
+func TestFrontend_Connect(t *testing.T) {
+	c, err := cluster.NewCluster(
+		cluster.WithFuddleNodes(1),
+		cluster.WithCounterNodes(1),
+		cluster.WithFrontendNodes(1),
+	)
+	require.NoError(t, err)
+	defer c.Shutdown()
 
-	// Locality is the location of the node in the cluster.
-	Locality string
+	resp, err := http.Get("http://" + c.FrontendAddrs()[0] + "/foo")
+	require.NoError(t, err)
+	defer resp.Body.Close()
 
-	// Revision is the build commit.
-	Revision string
+	assert.Equal(t, 200, resp.StatusCode)
 }

--- a/pkg/cli/demo/counter.go
+++ b/pkg/cli/demo/counter.go
@@ -146,7 +146,7 @@ func runCounterService(cmd *cobra.Command, args []string) error {
 #       Endpoint: ws://%s/{id}
 #       Locality: %s
 #       Logs: %s
-#`, conf.ID, conf.RPCAddr, conf.Locality, demoLogPath(logDir, conf.ID))
+#`, conf.ID, conf.WSAddr, conf.Locality, demoLogPath(logDir, conf.ID))
 		fmt.Println("")
 	}
 
@@ -183,7 +183,7 @@ func fuddleNodeConfig() *config.Config {
 func frontendNodeConfig(locality string) *frontend.Config {
 	return &frontend.Config{
 		ID:          "frontend-" + uuid.New().String()[:8],
-		RPCAddr:     testutils.GetSystemAddress(),
+		WSAddr:      testutils.GetSystemAddress(),
 		FuddleAddrs: []string{"127.0.0.1:8220"},
 		Locality:    locality,
 		Revision:    build.Revision,

--- a/pkg/cli/demo/counter.go
+++ b/pkg/cli/demo/counter.go
@@ -93,7 +93,10 @@ func runCounterService(cmd *cobra.Command, args []string) error {
 	frontendNodes = append(frontendNodes, frontendNodeConfig("us-east-1-c"))
 
 	for _, conf := range frontendNodes {
-		node := frontend.NewService(conf, demoLogger(logDir, fuddleConf.ID))
+		node := frontend.NewService(
+			conf,
+			frontend.WithLogger(demoLogger(logDir, fuddleConf.ID)),
+		)
 		if err := node.Start(); err != nil {
 			return fmt.Errorf("counter service: frontend node: %w", err)
 		}


### PR DESCRIPTION
# Description
Adds a frontend server to the counter service.

This doesn't yet do anything as the counter service only supports a single connection.